### PR TITLE
Syntax highlighting for markdown templates.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,110 @@
+module.exports = {
+  env: {
+    es6: true,
+    node: true
+  },
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: "tsconfig.json",
+    sourceType: "module"
+  },
+  plugins: ["@typescript-eslint", "@typescript-eslint/tslint", "prefer-arrow"],
+  rules: {
+    "@typescript-eslint/adjacent-overload-signatures": "error",
+    "@typescript-eslint/array-type": "error",
+    "@typescript-eslint/ban-types": "error",
+    "@typescript-eslint/naming-convention": ["error",
+      {
+	selector: "default",
+	format: ["camelCase"],
+	leadingUnderscore: "allow",
+	trailingUnderscore: "allow",
+      },
+      {
+	selector: "variable",
+	format: ["camelCase", "UPPER_CASE"],
+	leadingUnderscore: "allow",
+	trailingUnderscore: "allow",
+      },
+      {
+	selector: "enumMember",
+	format: ["PascalCase"],
+      },
+      {
+	selector: "typeLike",
+	format: ["PascalCase"],
+      }
+    ],
+    "@typescript-eslint/consistent-type-assertions": "error",
+    "@typescript-eslint/no-empty-function": "error",
+    "@typescript-eslint/no-empty-interface": "error",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-misused-new": "error",
+    "@typescript-eslint/no-namespace": "error",
+    "@typescript-eslint/no-parameter-properties": "off",
+    "@typescript-eslint/no-use-before-define": "off",
+    "@typescript-eslint/no-var-requires": "error",
+    "@typescript-eslint/prefer-for-of": "error",
+    "@typescript-eslint/prefer-function-type": "error",
+    "@typescript-eslint/prefer-namespace-keyword": "error",
+    "@typescript-eslint/triple-slash-reference": "error",
+    "@typescript-eslint/unified-signatures": "error",
+    "@typescript-eslint/no-shadow": "error",
+    "@typescript-eslint/tslint/config": [
+      "error",
+      {
+        rules: {
+          "jsdoc-format": true,
+          "no-reference-import": true
+        }
+      }
+    ],
+    camelcase: "error",
+    complexity: "off",
+    "constructor-super": "error",
+    "dot-notation": "error",
+    eqeqeq: ["error", "smart"],
+    "guard-for-in": "error",
+    "id-blacklist": [
+      "error",
+      "any",
+      "Number",
+      "number",
+      "String",
+      "string",
+      "Boolean",
+      "boolean",
+      "Undefined",
+      "undefined"
+    ],
+    "id-match": "error",
+    "max-classes-per-file": ["error", 1],
+    "new-parens": "error",
+    "no-bitwise": "error",
+    "no-caller": "error",
+    "no-cond-assign": "error",
+    "no-console": "off",
+    "no-debugger": "error",
+    "no-empty": "error",
+    "no-eval": "error",
+    "no-fallthrough": "off",
+    "no-invalid-this": "off",
+    "no-new-wrappers": "error",
+    "no-throw-literal": "error",
+    "no-trailing-spaces": "error",
+    "no-undef-init": "error",
+    "no-underscore-dangle": "error",
+    "no-unsafe-finally": "error",
+    "no-unused-expressions": "error",
+    "no-unused-labels": "error",
+    "no-var": "error",
+    "object-shorthand": "error",
+    "one-var": ["error", "never"],
+    "prefer-arrow/prefer-arrow-functions": "error",
+    "prefer-const": "error",
+    radix: "error",
+    "spaced-comment": "error",
+    "use-isnan": "error",
+    "valid-typeof": "off",
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ node_modules
 .public
 website.json
 template.html
-*.js
 !scripts/*js
 .vscode
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Configuration options:
 | `inputFormat` | The format of the input files. Support: `md` - Markdown, `txt` - Plain text files| `txt` |
 | `output`    | The output directory, where the index file will be generated. | `dist` |
 | `filename`  | The name of the index file. | `index.html` |
-| `highlight` | Enable syntax highlighting. Omit parameter for no syntax highlighting. Setting to empty string will set default theme. Themes are available at https://highlightjs.org/static/demo/.  Set to theme name for non-default theme. | false |
+| `highlight` | Enable syntax highlighting (only works with `md` parser). Omit parameter for no syntax highlighting. Setting to 'default' will set default theme. Themes are available at https://highlightjs.org/static/demo/.  Set to theme name for non-default theme. | undefined |
 <!-- prettier-ignore-end -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Example:
   "inputSort": "fs|git",
   "inputFormat": "txt|md",
   "output": "OutDirForHTMLFile",
-  "filename": "HTMLFileName"
+  "filename": "HTMLFileName",
+  "highlight": "theme-name"
 }
 ```
 
@@ -106,6 +107,7 @@ Configuration options:
 | `inputFormat` | The format of the input files. Support: `md` - Markdown, `txt` - Plain text files| `txt` |
 | `output`    | The output directory, where the index file will be generated. | `dist` |
 | `filename`  | The name of the index file. | `index.html` |
+| `highlight` | Enable syntax highlighting. Omit parameter for no syntax highlighting. Setting to empty string will set default theme. Themes are available at https://highlightjs.org/static/demo/.  Set to theme name for non-default theme. | false |
 <!-- prettier-ignore-end -->
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+# Internal TODO file. 
+
+### Syntax Highlighting
+- + Should be available via config variable for the markdown parser.
+- + `setup` step should be implemented across all the parsers as an abstract method.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  rootDir: "src"
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1470,6 +1470,21 @@
         "@types/node": "*"
       }
     },
+    "@types/highlight.js": {
+      "version": "9.12.4",
+      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.4.tgz",
+      "integrity": "sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==",
+      "dev": true
+    },
+    "@types/highlightjs": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@types/highlightjs/-/highlightjs-9.12.0.tgz",
+      "integrity": "sha512-MmUcjkDtCBfx2BPeLLTtJ5mFmGgWk9nAgZmNesixaGHOr0tCecsTU2iUgYvhRsWJSts2WbcpAtVPuIzZ0ybJ1A==",
+      "dev": true,
+      "requires": {
+        "@types/highlight.js": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -3552,6 +3567,11 @@
           }
         }
       }
+    },
+    "highlight.js": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.3.1.tgz",
+      "integrity": "sha512-jeW8rdPdhshYKObedYg5XGbpVgb1/DT4AHvDFXhkU7UnGSIjy9kkJ7zHG7qplhFHMitTSzh5/iClKQk3Kb2RFQ=="
     },
     "hosted-git-info": {
       "version": "2.8.8",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "author": "Jurgis Bridzius",
   "devDependencies": {
+    "@types/highlightjs": "^9.12.0",
     "@types/jest": "^26.0.14",
     "@types/marked": "^1.1.0",
     "@types/node": "^14.11.2",
@@ -37,6 +38,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
+    "highlight.js": "^10.3.1",
     "marked": "^1.2.0"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export interface IBlankConfig {
         subheader: string;
         header: string;
     };
+    highlight: string | undefined;
 }
 
 export const getConfigFile = (args: string[]) => {
@@ -37,6 +38,7 @@ export class BlankpageConfig implements IBlankConfig {
     public inputFormat: ParserTypes;
     public output: string;
     public slots: { subheader: string; header: string };
+    public highlight: string | undefined;
     constructor(confpath: any) {
         const conf = getBlankConf(confpath);
         validate(conf);
@@ -49,6 +51,7 @@ export class BlankpageConfig implements IBlankConfig {
         this.slots.header = conf.header || "";
         this.slots.subheader = conf.subheader || "";
         this.filename = conf.filename || "index.html";
+        this.highlight = conf.highlight;
     }
 }
 

--- a/src/parsers/md.parser.ts
+++ b/src/parsers/md.parser.ts
@@ -1,7 +1,11 @@
-import { Parser } from "./parser";
+import { Parser, ParserOptions } from "./parser";
 import * as marked from "marked";
 import { readFileSync } from "fs";
+import { join, resolve, sep } from "path";
 import { ParserTypes } from "../types";
+import { IBlankConfig } from "../config";
+import * as hljs from "highlight.js";
+import { existsSync } from "fs";
 
 export class MarkdownParser implements Parser {
     private parserType = ParserTypes.Markdown;
@@ -10,5 +14,29 @@ export class MarkdownParser implements Parser {
     }
     public parse(inputFile: string): string {
         return marked(readFileSync(inputFile).toString());
+    }
+    public setup(config: IBlankConfig): ParserOptions {
+        let options: ParserOptions = {};
+        if (typeof config.highlight !== "undefined") {
+            const highlightModulePath = require
+                .resolve("highlight.js")
+                .split(sep);
+            const highlightStyles = highlightModulePath
+                .slice(0, highlightModulePath.indexOf("highlight.js") + 1)
+                .concat(["styles", `${config.highlight}.css`]);
+            const stylesPath = join(`${sep}`, ...highlightStyles);
+            const pathExists = existsSync(stylesPath);
+            const addStyle = pathExists
+                ? readFileSync(stylesPath).toString()
+                : "";
+            options = { ...options, addStyle };
+            marked.setOptions({
+                langPrefix: "hljs language-",
+                highlight: (code, lang) => {
+                    return hljs.highlightAuto(code, [lang]).value;
+                },
+            });
+        }
+        return options;
     }
 }

--- a/src/parsers/parser.ts
+++ b/src/parsers/parser.ts
@@ -1,6 +1,13 @@
+import { IBlankConfig } from "../config";
 import { ParserTypes } from "../types";
+
+export interface ParserOptions {
+    addStyle?: string;
+    addStyleExt?: string;
+}
 
 export abstract class Parser {
     public abstract get label(): ParserTypes;
     public abstract parse(input: string): string;
+    public abstract setup(config: IBlankConfig): ParserOptions;
 }

--- a/src/parsers/plain.parser.ts
+++ b/src/parsers/plain.parser.ts
@@ -1,6 +1,7 @@
-import { Parser } from "./parser";
+import { Parser, ParserOptions } from "./parser";
 import { readFileSync } from "fs";
 import { ParserTypes } from "../types";
+import { IBlankConfig } from "../config";
 export class PlainParser implements Parser {
     private parserType = ParserTypes.Plain;
     public get label() {
@@ -8,5 +9,8 @@ export class PlainParser implements Parser {
     }
     public parse(inputFile: string): string {
         return readFileSync(inputFile).toString();
+    }
+    public setup(_config: IBlankConfig): ParserOptions {
+        return {};
     }
 }

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -2,17 +2,17 @@ import { sortCompare } from "./utils";
 
 describe("Blankpage utils", () => {
     describe("#sortCompare", () => {
-        it('should sort lower numbers as last', () => {
-            const input = [200,300];
+        it("should sort lower numbers as last", () => {
+            const input = [200, 300];
             expect(input.sort(sortCompare)).toEqual([300, 200]);
         });
-        it('should sort higher numbers as first', () => {
+        it("should sort higher numbers as first", () => {
             const input = [5000, 60000, 1];
             expect(input.sort(sortCompare)).toEqual([60000, 5000, 1]);
         });
-        it('should leave identical numbers as is', () => {
+        it("should leave identical numbers as is", () => {
             const input = [100, 80, 90, 90];
             expect(input.sort(sortCompare)).toEqual([100, 90, 90, 80]);
-        })
-    })
-})
+        });
+    });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,1 +1,2 @@
-export const sortCompare = (a: number, b: number): number =>  a > b ? -1 : b > a ? 1 : 0;
+export const sortCompare = (a: number, b: number): number =>
+    a > b ? -1 : b > a ? 1 : 0;

--- a/src/writer.ts
+++ b/src/writer.ts
@@ -2,8 +2,18 @@ import { IBlankConfig } from "./config";
 import { join } from "path";
 import { cwd } from "process";
 import { existsSync, readFileSync } from "fs";
+import { ParserOptions } from "./parsers/parser";
 
-const getIndexTemplate = (data: IBlankConfig) => {
+const getHeadContent = (title: string, parserOpts: ParserOptions): string => {
+    let head = "<head>";
+    if (title) head += `\n<title>${title}</title>`;
+    if (parserOpts.addStyle) {
+        head += `\n<style>${parserOpts.addStyle}</style>`;
+    }
+    return head;
+};
+
+const getIndexTemplate = (data: IBlankConfig, parserOpts: ParserOptions) => {
     const templatePath = join(cwd(), "template.html");
     const templateExists = existsSync(templatePath);
     if (!templateExists) {
@@ -12,7 +22,7 @@ const getIndexTemplate = (data: IBlankConfig) => {
     let template = readFileSync(templatePath).toString();
     template = template.replace(
         "<head>",
-        `<head>\n<title>${data.title}</title>`
+        getHeadContent(data.title, parserOpts)
     );
     Object.keys(data.slots).forEach((slot: "header" | "subheader") => {
         template = template.replace(
@@ -23,8 +33,12 @@ const getIndexTemplate = (data: IBlankConfig) => {
     return template.split("<//CONTENT//>");
 };
 
-export const renderTemplate = (posts: string[], config: IBlankConfig) => {
-    const template = getIndexTemplate(config);
+export const renderTemplate = (
+    posts: string[],
+    config: IBlankConfig,
+    parserOpts: ParserOptions
+) => {
+    const template = getIndexTemplate(config, parserOpts);
     const content = posts.reduce(
         (current, post) => (current += `<article>\n${post}</article>\n`),
         ""


### PR DESCRIPTION
Introducing syntax highlighting. This can definitely still be simplified, but it works.
Uses `hightlight.js` for the actual highlighting and supports all the themes from `highlight.js` by default.